### PR TITLE
Docker build changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+pyenv/
 
 # Spyder project settings
 .spyderproject
@@ -156,3 +157,5 @@ data/
 logs/
 !BundleTrack/XMem/inference/data
 run_used.yml
+
+output.txt

--- a/build_all.sh
+++ b/build_all.sh
@@ -1,7 +1,10 @@
 DIR=$(pwd)
 
 cd $DIR/mycpp/ && mkdir -p build && cd build && cmake .. -DPYTHON_EXECUTABLE=$(which python) && make -j11
-cd /kaolin && rm -rf build *egg* && pip install -e .
-cd $DIR/bundlesdf/mycuda && rm -rf build *egg* && pip install -e .
+
+# Disable Kaolin and BundleSDF as we are not doing model-free object pose estimation.
+# We currently only perform object pose estimation given their 3D models are provided as input. 
+#cd /kaolin && rm -rf build *egg* && pip install -e .
+#cd $DIR/bundlesdf/mycuda && rm -rf build *egg* && pip install -e .
 
 cd ${DIR}

--- a/bundlesdf/mycuda/setup.py
+++ b/bundlesdf/mycuda/setup.py
@@ -15,8 +15,8 @@ from torch.utils.cpp_extension import load
 code_dir = os.path.dirname(os.path.realpath(__file__))
 
 
-nvcc_flags = ['-Xcompiler', '-O3', '-std=c++14', '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__']
-c_flags = ['-O3', '-std=c++14']
+nvcc_flags = ['-Xcompiler', '-O3', '-std=c++17', '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__']
+c_flags = ['-O3', '-std=c++17']
 
 setup(
     name='common',

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -5,15 +5,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 curl ca-certificates wget ca-certificates gnupg gcc g++ make \
     && rm -rf /var/lib/apt/lists/*
 
-### BEGIN of CUDA installation ###
+##### BEGIN of CUDA 12.1 toolkit installation #####
 
-# Download and install libtinfo5, Ubuntu 24.04 has moved to libtinfo6. The former is still used by CUDA 12.4.
+# Download and install libtinfo5, Ubuntu 24.04 has moved to libtinfo6. 
+# The former is still used by CUDA toolkit up to 12.4 at least (and consequently 12.1).
 RUN wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb \
     && dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb \
     && rm libtinfo5_6.3-2ubuntu0.1_amd64.deb
 
 
-# Install NVIDIA CUDA 12.4 Toolkit from NVIDIA's official package repository for Ubuntu 22.04 (there's no version for 24.04 sadly)
+# Install NVIDIA CUDA 12.1 Toolkit from NVIDIA's official package repository for Ubuntu 22.04.
+# (NVIDIA repos repositories don't have it for Ubuntu 24.04).
 
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
 RUN dpkg -i cuda-keyring_1.1-1_all.deb
@@ -24,10 +26,10 @@ RUN apt-get install -y cuda-toolkit-12-1
 ENV PATH=/usr/local/cuda-12.1/bin:${PATH}
 ENV LD_LIBRARY_PATH=/usr/local/cuda-12.1/lib64:${LD_LIBRARY_PATH}
 
-# Ensure CUDA installation
+# Ensure CUDA toolkit installation
 RUN nvcc --version
 
-### END of CUDA installation ###
+##### END of CUDA toolkit installation #####
 
 
 ENV TZ=US/Pacific
@@ -35,8 +37,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update --fix-missing && \
     apt-get install -y libgtk2.0-dev && \
-    apt-get install -y wget bzip2 ca-certificates curl git vim tmux g++ gcc build-essential cmake checkinstall gfortran libjpeg8-dev libtiff5-dev pkg-config yasm libavcodec-dev libavformat-dev libswscale-dev 
-    # libdc1394-22-dev libxine2-dev libv4l-dev qt5-default libgtk2.0-dev libtbb-dev libatlas-base-dev libfaac-dev libmp3lame-dev libtheora-dev libvorbis-dev libxvidcore-dev libopencore-amrnb-dev libopencore-amrwb-dev x264 v4l-utils libprotobuf-dev protobuf-compiler libgoogle-glog-dev libgflags-dev libgphoto2-dev libhdf5-dev doxygen libflann-dev libboost-all-dev proj-data libproj-dev libyaml-cpp-dev cmake-curses-gui libzmq3-dev freeglut3-dev
+    apt-get install -y wget bzip2 ca-certificates curl git vim tmux g++ gcc build-essential cmake checkinstall gfortran libjpeg8-dev libtiff5-dev pkg-config yasm libavcodec-dev libavformat-dev libswscale-dev
 
 
 RUN cd / && git clone https://github.com/pybind/pybind11 &&\
@@ -74,9 +75,11 @@ RUN conda init bash &&\
 RUN pip install "git+https://github.com/facebookresearch/pytorch3d.git@stable"
 RUN pip install scipy joblib scikit-learn ruamel.yaml trimesh pyyaml opencv-python imageio open3d transformations warp-lang einops kornia pyrender
 
-RUN cd / && git clone --recursive https://github.com/NVIDIAGameWorks/kaolin
-RUN conda activate my && cd /kaolin &&\
-    FORCE_CUDA=1 python setup.py develop
+# Skip NVIDIA KAOLIN installation for now. We don't need it because we are only going to perform 3D model-based pose estimation.
+# Kaolin is solely used for model-free pose estimation pipelines.
+# RUN cd / && git clone --recursive https://github.com/NVIDIAGameWorks/kaolin
+# RUN conda activate my && cd /kaolin &&\
+#     FORCE_CUDA=1 python setup.py develop
 
 RUN cd / && git clone https://github.com/NVlabs/nvdiffrast &&\
     conda activate my && cd /nvdiffrast && pip install .
@@ -89,7 +92,8 @@ RUN conda activate my &&\
 
 RUN apt-get install -y libboost-all-dev
 
-# Need to install gcc-12 and g++-12 because NVCC in CUDA 12.1 does not support GNU versions above 12:
+# Need to install gcc-12 and g++-12 because NVCC in CUDA 12.1 does not support GNU versions above 12.
+# Ubuntu 24.04 has moved to 13.x versions.
 RUN apt update &&\
     apt install -y gcc-12 g++-12 &&\
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 &&\

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -85,8 +85,25 @@ RUN apt update &&\
     update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-12 12 &&\
     update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 12
 
+# Need to downgrade numpy because PyBind 2.10.0 is incompatible with Numpy 2.x.
 RUN pip install 'numpy<2'
 
 ENV NVIDIA_DISABLE_REQUIRE=1
 ENV SHELL=/bin/bash
 RUN ln -sf /bin/bash /bin/sh
+
+COPY demo_data demo_data
+
+COPY learning learning
+COPY mycpp mycpp
+COPY weights weights
+COPY datareader.py datareader.py
+COPY estimater.py estimater.py
+COPY offscreen_renderer.py offscreen_renderer.py
+COPY run_demo.py run_demo.py
+COPY Utils.py Utils.py
+
+COPY build_all.sh build_all.sh
+RUN chmod +x build_all.sh
+RUN ./build_all.sh
+CMD ["python", "run_demo.py"]

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,11 +1,42 @@
-FROM nvidia/cudagl:11.3.0-devel-ubuntu20.04
+FROM ubuntu:24.04   
+
+# Install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gnupg2 curl ca-certificates wget ca-certificates gnupg gcc g++ make \
+    && rm -rf /var/lib/apt/lists/*
+
+### BEGIN of CUDA installation ###
+
+# Download and install libtinfo5, Ubuntu 24.04 has moved to libtinfo6. The former is still used by CUDA 12.4.
+RUN wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb \
+    && dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb \
+    && rm libtinfo5_6.3-2ubuntu0.1_amd64.deb
+
+
+# Install NVIDIA CUDA 12.4 Toolkit from NVIDIA's official package repository for Ubuntu 22.04 (there's no version for 24.04 sadly)
+
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+RUN dpkg -i cuda-keyring_1.1-1_all.deb
+RUN apt-get update
+RUN apt-get install -y cuda-toolkit-12-1
+
+# Set environment variables
+ENV PATH=/usr/local/cuda-12.1/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/cuda-12.1/lib64:${LD_LIBRARY_PATH}
+
+# Ensure CUDA installation
+RUN nvcc --version
+
+### END of CUDA installation ###
+
 
 ENV TZ=US/Pacific
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update --fix-missing && \
     apt-get install -y libgtk2.0-dev && \
-    apt-get install -y wget bzip2 ca-certificates curl git vim tmux g++ gcc build-essential cmake checkinstall gfortran libjpeg8-dev libtiff5-dev pkg-config yasm libavcodec-dev libavformat-dev libswscale-dev libdc1394-22-dev libxine2-dev libv4l-dev qt5-default libgtk2.0-dev libtbb-dev libatlas-base-dev libfaac-dev libmp3lame-dev libtheora-dev libvorbis-dev libxvidcore-dev libopencore-amrnb-dev libopencore-amrwb-dev x264 v4l-utils libprotobuf-dev protobuf-compiler libgoogle-glog-dev libgflags-dev libgphoto2-dev libhdf5-dev doxygen libflann-dev libboost-all-dev proj-data libproj-dev libyaml-cpp-dev cmake-curses-gui libzmq3-dev freeglut3-dev
+    apt-get install -y wget bzip2 ca-certificates curl git vim tmux g++ gcc build-essential cmake checkinstall gfortran libjpeg8-dev libtiff5-dev pkg-config yasm libavcodec-dev libavformat-dev libswscale-dev 
+    # libdc1394-22-dev libxine2-dev libv4l-dev qt5-default libgtk2.0-dev libtbb-dev libatlas-base-dev libfaac-dev libmp3lame-dev libtheora-dev libvorbis-dev libxvidcore-dev libopencore-amrnb-dev libopencore-amrwb-dev x264 v4l-utils libprotobuf-dev protobuf-compiler libgoogle-glog-dev libgflags-dev libgphoto2-dev libhdf5-dev doxygen libflann-dev libboost-all-dev proj-data libproj-dev libyaml-cpp-dev cmake-curses-gui libzmq3-dev freeglut3-dev
 
 
 RUN cd / && git clone https://github.com/pybind/pybind11 &&\
@@ -38,9 +69,10 @@ ENV PATH $PATH:/opt/conda/envs/my/bin
 RUN conda init bash &&\
     echo "conda activate my" >> ~/.bashrc &&\
     conda activate my &&\
-    pip install torch==2.0.0+cu118 torchvision==0.15.1+cu118 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu118 &&\
-    pip install "git+https://github.com/facebookresearch/pytorch3d.git@stable" &&\
-    pip install scipy joblib scikit-learn ruamel.yaml trimesh pyyaml opencv-python imageio open3d transformations warp-lang einops kornia pyrender
+    pip install torchvision==0.16.0+cu121 torchaudio==2.1.0 torch==2.1.0+cu121 --index-url https://download.pytorch.org/whl/cu121
+
+RUN pip install "git+https://github.com/facebookresearch/pytorch3d.git@stable"
+RUN pip install scipy joblib scikit-learn ruamel.yaml trimesh pyyaml opencv-python imageio open3d transformations warp-lang einops kornia pyrender
 
 RUN cd / && git clone --recursive https://github.com/NVIDIAGameWorks/kaolin
 RUN conda activate my && cd /kaolin &&\
@@ -55,6 +87,15 @@ RUN conda activate my &&\
     pip install scikit-image meshcat webdataset omegaconf pypng roma seaborn opencv-contrib-python openpyxl wandb imgaug Ninja xlsxwriter timm albumentations xatlas rtree nodejs jupyterlab objaverse g4f ultralytics==8.0.120 pycocotools videoio numba &&\
     conda install -y -c anaconda h5py
 
+RUN apt-get install -y libboost-all-dev
+
+# Need to install gcc-12 and g++-12 because NVCC in CUDA 12.1 does not support GNU versions above 12:
+RUN apt update &&\
+    apt install -y gcc-12 g++-12 &&\
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12 &&\
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12 &&\
+    update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-12 12 &&\
+    update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 12
 
 ENV SHELL=/bin/bash
 RUN ln -sf /bin/bash /bin/sh

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -31,11 +31,7 @@ RUN nvcc --version
 
 ##### END of CUDA toolkit installation #####
 
-
-ENV TZ=US/Pacific
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-RUN apt-get update --fix-missing && \
+RUN apt-get update && \
     apt-get install -y libgtk2.0-dev && \
     apt-get install -y wget bzip2 ca-certificates curl git vim tmux g++ gcc build-essential cmake checkinstall gfortran libjpeg8-dev libtiff5-dev pkg-config yasm libavcodec-dev libavformat-dev libswscale-dev
 
@@ -43,7 +39,7 @@ RUN apt-get update --fix-missing && \
 RUN cd / && git clone https://github.com/pybind/pybind11 &&\
     cd pybind11 && git checkout v2.10.0 &&\
     mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DPYBIND11_INSTALL=ON -DPYBIND11_TEST=OFF &&\
-    make -j6 && make install
+    make -j$(nproc) && make install
 
 
 RUN cd / && wget https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz &&\
@@ -56,23 +52,13 @@ RUN cd / && wget https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.t
 
 SHELL ["/bin/bash", "--login", "-c"]
 
-RUN cd / && wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /miniconda.sh && \
-    /bin/bash /miniconda.sh -b -p /opt/conda &&\
-    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh &&\
-    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc &&\
-    /bin/bash -c "source ~/.bashrc" && \
-    /opt/conda/bin/conda update -n base -c defaults conda -y &&\
-    /opt/conda/bin/conda create -n my python=3.8
+RUN apt-get install -y python-is-python3 python3-pip python3.12-venv
+RUN python -m pip config set global.break-system-packages true
 
 
-ENV PATH $PATH:/opt/conda/envs/my/bin
+RUN pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu121
 
-RUN conda init bash &&\
-    echo "conda activate my" >> ~/.bashrc &&\
-    conda activate my &&\
-    pip install torchvision==0.16.0+cu121 torchaudio==2.1.0 torch==2.1.0+cu121 --index-url https://download.pytorch.org/whl/cu121
-
-RUN pip install "git+https://github.com/facebookresearch/pytorch3d.git@stable"
+RUN MAX_JOBS=$(nproc) pip install "git+https://github.com/facebookresearch/pytorch3d.git@stable"
 RUN pip install scipy joblib scikit-learn ruamel.yaml trimesh pyyaml opencv-python imageio open3d transformations warp-lang einops kornia pyrender
 
 # Skip NVIDIA KAOLIN installation for now. We don't need it because we are only going to perform 3D model-based pose estimation.
@@ -81,14 +67,12 @@ RUN pip install scipy joblib scikit-learn ruamel.yaml trimesh pyyaml opencv-pyth
 # RUN conda activate my && cd /kaolin &&\
 #     FORCE_CUDA=1 python setup.py develop
 
-RUN cd / && git clone https://github.com/NVlabs/nvdiffrast &&\
-    conda activate my && cd /nvdiffrast && pip install .
+RUN cd / && git clone https://github.com/NVlabs/nvdiffrast && cd /nvdiffrast && pip install .
 
 ENV OPENCV_IO_ENABLE_OPENEXR=1
 
-RUN conda activate my &&\
-    pip install scikit-image meshcat webdataset omegaconf pypng roma seaborn opencv-contrib-python openpyxl wandb imgaug Ninja xlsxwriter timm albumentations xatlas rtree nodejs jupyterlab objaverse g4f ultralytics==8.0.120 pycocotools videoio numba &&\
-    conda install -y -c anaconda h5py
+RUN pip install scikit-image meshcat webdataset omegaconf pypng roma seaborn opencv-contrib-python openpyxl wandb imgaug Ninja xlsxwriter timm albumentations xatlas rtree nodejs jupyterlab objaverse g4f ultralytics==8.0.120 pycocotools videoio numba
+RUN pip install h5py
 
 RUN apt-get install -y libboost-all-dev
 
@@ -100,6 +84,8 @@ RUN apt update &&\
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12 &&\
     update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-12 12 &&\
     update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 12
+
+RUN pip install 'numpy<2'
 
 ENV NVIDIA_DISABLE_REQUIRE=1
 ENV SHELL=/bin/bash

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -97,5 +97,6 @@ RUN apt update &&\
     update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-12 12 &&\
     update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 12
 
+ENV NVIDIA_DISABLE_REQUIRE=1
 ENV SHELL=/bin/bash
 RUN ln -sf /bin/bash /bin/sh

--- a/docker/run_container.sh
+++ b/docker/run_container.sh
@@ -1,3 +1,15 @@
+#!/bin/bash
+
 docker rm -f foundationpose
 DIR=$(pwd)/../
-xhost +  && docker run --gpus all --env NVIDIA_DISABLE_REQUIRE=1 -it --network=host --name foundationpose  --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -v $DIR:$DIR -v /home:/home -v /mnt:/mnt -v /tmp/.X11-unix:/tmp/.X11-unix -v /tmp:/tmp  --ipc=host -e DISPLAY=${DISPLAY} -e GIT_INDEX_FILE foundationpose:latest bash -c "cd $DIR && bash"
+
+xhost +local:docker &&\
+docker run \
+    --gpus all \
+    -it \
+    --name foundationpose \
+    -v $DIR:$DIR \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e DISPLAY=${DISPLAY} \
+    foundationpose_custom:latest \
+    bash -c "cd $DIR && bash"

--- a/docker/run_container.sh
+++ b/docker/run_container.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker rm -f foundationpose
+docker rm -f foundationpose 2>/dev/null || true
 DIR=$(pwd)/../
 
 xhost +local:docker &&\
@@ -8,8 +8,7 @@ docker run \
     --gpus all \
     -it \
     --name foundationpose \
-    -v $DIR:$DIR \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -e DISPLAY=${DISPLAY} \
-    foundationpose_custom:latest \
-    bash -c "cd $DIR && bash"
+    foundationpose_custom:latest
+

--- a/mycpp/CMakeLists.txt
+++ b/mycpp/CMakeLists.txt
@@ -4,7 +4,7 @@ project(mycpp)
 
 set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fopenmp -g3 -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fopenmp -g3 -O3")
 
 
 find_package(Boost REQUIRED COMPONENTS system program_options)
@@ -19,7 +19,7 @@ include_directories(
 
 file(GLOB MY_SRC ${PROJECT_SOURCE_DIR}/src/*.cpp)
 
-set(PYBIND11_CPP_STANDARD -std=c++14)
+set(PYBIND11_CPP_STANDARD -std=c++17)
 
 pybind11_add_module(mycpp src/app/pybind_api.cpp ${MY_SRC})
 target_link_libraries(mycpp PRIVATE ${Boost_LIBRARIES} ${OpenMP_CXX_FLAGS} Eigen3::Eigen)


### PR DESCRIPTION
- Disables model-free based pose estimation (Kaolin and BundleSDF modules). We don't need it for our purposes for the time being.
- Improves Dockerfile: 
  - upgrades to Ubuntu 24.04, CUDA Toolkit 12.1, C++ 17, PyTorch 2.2.2
  - drops dependency on Miniconda
  - avoids installation of many unnecessary packages
  - drops mounting folders from outside the container - copies codebase and artifacts instead
  - improves docker runtime security - removes some unnecessary `docker run` options 